### PR TITLE
fix output file failing.

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -262,7 +262,7 @@ def speed_up_video(
         '-i', input_file,
         '-i', temp_folder + '/audioNew.wav',
         '-filter_script:v', temp_folder + '/filterGraph.txt',
-        '-map', '0',
+        '-map', '0:v',
         '-map', '-0:a',
         '-map', '1:a',
         '-c:a', 'aac',


### PR DESCRIPTION
the -map 0 line would also try to map a subtitle file. so I replaced it with -map 0:v so it will only do audio and video.